### PR TITLE
replace a missing definition train_parameters with parameters

### DIFF
--- a/bin/train_trajectron.py
+++ b/bin/train_trajectron.py
@@ -67,5 +67,5 @@ if __name__ == "__main__":
     with open(parameters.config, "r", encoding="utf-8") as config_json:
         model_parameters = json.load(config_json)
     override_parameters(model_parameters, parameters)
-    trainer = train.Trainer(train_parameters, model_parameters)
+    trainer = train.Trainer(parameters, model_parameters)
     trainer.fit()


### PR DESCRIPTION
*Issue 12, if available:* Missing defined variable train_parameters in bin/train_trajectron.py

*Description of changes:* Change `train_parameters` to `parameters` in bin/train_trajectron.py as discussed in the issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
